### PR TITLE
Fix import

### DIFF
--- a/rtfd/rtfd.py
+++ b/rtfd/rtfd.py
@@ -1,7 +1,7 @@
 from bs4 import BeautifulSoup
 from colorama import init, Fore, Style
 from tqdm import tqdm
-from helpers import formatstr
+from .helpers import formatstr
 import requests
 import json
 import argparse


### PR DESCRIPTION
I got exception when installed from pip - python 3.5

```
 $ rtfd-cli
Traceback (most recent call last):
  File "/home/hvn/py35env/bin/rtfd-cli", line 7, in <module>
    from rtfd.rtfd import command_line
  File "/home/hvn/py35env/lib/python3.5/site-packages/rtfd/rtfd.py", line 4, in <module>
    from helpers import formatstr
ImportError: No module named 'helpers'

```