### PR TITLE
Cleanup, rm unnecessary arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
-import rtfd
 
-setup(name='rtfd-cli',
+setup(
+      name='rtfd-cli',
       version='0.1',
       description='CLI to download docs from ReadTheDocs.org',
       author='Nitanshu Vashistha',
       author_email='nitanshu.vzard@gmail.com',
-      packages = find_packages(),
+      packages=find_packages(),
       entry_points={
             'console_scripts': [
                   'rtfd-cli = rtfd.rtfd:command_line',
@@ -15,7 +15,6 @@ setup(name='rtfd-cli',
       url='https://github.com/MUSoC/rtfd-cli',
       keywords=['readthedocs', 'terminal', 'command-line', 'rtfd', 'python'],
       license='MIT',
-      downlaod_url='https://github.com/nvzard/rtfd-cli/archive/0.1.tar.gz',
       classifiers=[],
       install_requires=[
             'requests',
@@ -23,4 +22,4 @@ setup(name='rtfd-cli',
             'tqdm',
             'colorama'
       ]
-     )
+)


### PR DESCRIPTION
The `download_url` has typo, and as user will install the tool by `pip` , not sure why we need the download url.

Consulted requests https://github.com/requests/requests/blob/master/setup.py and they also does not use the arg.