### PR TITLE
Handle when there is no desc

### DIFF
--- a/rtfd/rtfd.py
+++ b/rtfd/rtfd.py
@@ -44,10 +44,20 @@ def title_scraper(query):
     source_code = requests.get(url).text
     soup = BeautifulSoup(source_code, 'html.parser')
     for p in soup.find_all('li', {'class': 'module-item'}):
-        title_p, desc_p, *_ =  p.find_all('p')
+        ps = p.find_all('p')
+
+        try:
+            title_p, desc_p, *_ = ps
+        except ValueError:
+            # some results have no description
+            title_p = ps[0]
+            desc = ''
+        else:
+            desc = desc_p.get_text()
+
         title = title_p.find('a').string
-        desc = desc_p.get_text()
         desc = decode_description(desc)
+
         project_titles.append(title)
         project_descs.append(desc)
     return project_titles, project_descs


### PR DESCRIPTION
There are search results which have no description

```
 $ rtfd-cli sqlalchemy
Traceback (most recent call last):
  File "/home/hvn/py35env/bin/rtfd-cli", line 11, in <module>
    load_entry_point('rtfd-cli', 'console_scripts', 'rtfd-cli')()
  File "/media/media/FOSS/rtfd-cli/rtfd/rtfd.py", line 183, in command_line
    rtfd(query,dir)
  File "/media/media/FOSS/rtfd-cli/rtfd/rtfd.py", line 161, in rtfd
    all_titles, all_descs = title_scraper(query)
  File "/media/media/FOSS/rtfd-cli/rtfd/rtfd.py", line 47, in title_scraper
    title_p, desc_p, *_ =  p.find_all('p')
ValueError: not enough values to unpack (expected at least 2, got 1)

```

This MR set those desc to empty